### PR TITLE
SH4RE-127-Add-select-all-text-on-search-bar-click-for-easy-clearing

### DIFF
--- a/SH4RE/SH4RE/Home/HomeView.swift
+++ b/SH4RE/SH4RE/Home/HomeView.swift
@@ -41,7 +41,8 @@ struct HomeView: View {
                     }, label:{
                         Image(systemName: "magnifyingglass")
                     }),
-                    colour: .gray
+                    colour: .gray,
+                    clearFunc: searchModel.searchQuery == "" ? nil : {searchModel.searchQuery = ""}
                 )
             )
             .focused($isFocusOn)

--- a/SH4RE/SH4RE/Search/SearchView.swift
+++ b/SH4RE/SH4RE/Search/SearchView.swift
@@ -71,7 +71,8 @@ struct SearchView: View {
                     }, label:{
                         Image(systemName: "magnifyingglass")
                     }),
-                    colour: .gray
+                    colour: .gray,
+                    clearFunc: searchModel.searchQuery == "" ? nil : {searchModel.searchQuery = ""}
                 )
             )
             .focused($isFocusOn)

--- a/SH4RE/SH4RE/Styles/TextFieldStyles.swift
+++ b/SH4RE/SH4RE/Styles/TextFieldStyles.swift
@@ -44,6 +44,8 @@ struct iconInputStyle: TextFieldStyle{
     var button: Button<Image>
     var disableButton: Bool = false
     var colour: Color = .accentColor
+    /// If set, it will enable a clear button which when pressed, calls the passed function from this variable
+    var clearFunc: (() -> Void)? = nil
     
     var buttonColour: Color {
         return disableButton ? .gray : colour
@@ -62,6 +64,13 @@ struct iconInputStyle: TextFieldStyle{
             // Text color.
                 .foregroundColor(.black)
                 .padding(.leading, 5)
+            if (clearFunc != nil){
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(.textfield)
+                    .onTapGesture {
+                        clearFunc!()
+                    }
+            }
         }
         // TextField spacing.
         .padding(.vertical, 16)
@@ -100,7 +109,7 @@ struct TextFieldStyles_PreviewsHelper: View {
                     iconInputStyle(button: Button(action:{},
                                                       label:{
                                                           Image(systemName: "scope")
-                                                      }))
+                                                      }), clearFunc: username == "" ? nil : {username = ""})
                 )
         }
     }


### PR DESCRIPTION
Add an optional clear function to iconInputStyle which when set, enables a clear button on the text field for clearing input

https://user-images.githubusercontent.com/46950469/229686202-c8ae3a7f-f7fc-4837-a9eb-ecae9457712d.mov

