### PR TITLE
SH4RE-137-Make-Favs-Sync

### DIFF
--- a/SH4RE/SH4RE/Account/AccountView.swift
+++ b/SH4RE/SH4RE/Account/AccountView.swift
@@ -46,7 +46,7 @@ struct AccountView: View {
     private var menu: some View {
         VStack {
             NavigationLink(destination: {
-                MyListingsView(tabSelection: $tabSelection)
+                MyListingsView(tabSelection: $tabSelection, favouritesModel: favouritesModel)
                     .environmentObject(currentUser)
             }, label: {
                 HStack {

--- a/SH4RE/SH4RE/Account/FavouritesModel.swift
+++ b/SH4RE/SH4RE/Account/FavouritesModel.swift
@@ -18,6 +18,7 @@ class FavouritesModel: ObservableObject {
     
     fileprivate func getFavouritesFromServer() {
         if(Auth.auth().currentUser != nil){
+            removeAll()
             Firestore.firestore().collection("User Info").document(getCurrentUserUid()).collection("Favourites").getDocuments() {(snapshot, error) in
                 snapshot?.documents.forEach({ (document) in
                     let id = document.documentID

--- a/SH4RE/SH4RE/Account/FavouritesView.swift
+++ b/SH4RE/SH4RE/Account/FavouritesView.swift
@@ -35,7 +35,7 @@ struct FavouritesView: View {
                             // If theres no image for a listing, just use the placeholder
                             let productImage = listingsView.image_dict[listing.id] ?? UIImage(named: "placeholder")!
                             NavigationLink(destination: {
-                                ViewListingView(tabSelection: $tabSelection, listing: listing, chatLogViewModel: chatLogViewModelDict[listing.id] ?? ChatLogViewModel(chatUser: ChatUser(id: listing.uid,uid: listing.uid, name: listing.ownerName))).environmentObject(currentUser)
+                                ViewListingView(tabSelection: $tabSelection, favouritesModel: favouritesModel, listing: listing, chatLogViewModel: chatLogViewModelDict[listing.id] ?? ChatLogViewModel(chatUser: ChatUser(id: listing.uid,uid: listing.uid, name: listing.ownerName))).environmentObject(currentUser)
                             }, label: {
                                 ProductCard(favouritesModel: favouritesModel, listing: listing, image: productImage)
                             })

--- a/SH4RE/SH4RE/Account/MyListingsView.swift
+++ b/SH4RE/SH4RE/Account/MyListingsView.swift
@@ -11,6 +11,7 @@ struct MyListingsView: View {
     @Binding var tabSelection: Int
     @EnvironmentObject var currentUser: CurrentUser
     @StateObject private var listingsView = ListingViewModel()
+    @ObservedObject var favouritesModel: FavouritesModel
     var columns = [GridItem(.adaptive(minimum: 160), spacing: 15)]
 
     var body: some View {
@@ -31,9 +32,9 @@ struct MyListingsView: View {
                             // If theres no image for a listing, just use the placeholder
                             let productImage = listingsView.image_dict[listing.id] ?? UIImage(named: "placeholder")!
                             NavigationLink(destination: {
-                                ViewListingView(tabSelection: $tabSelection, listing: listing, chatLogViewModel: ChatLogViewModel(chatUser: ChatUser(id: listing.uid,uid: listing.uid, name: ""))).environmentObject(currentUser)
+                                ViewListingView(tabSelection: $tabSelection, favouritesModel: favouritesModel, listing: listing, chatLogViewModel: ChatLogViewModel(chatUser: ChatUser(id: listing.uid,uid: listing.uid, name: ""))).environmentObject(currentUser)
                             }, label: {
-                                ProductCard(favouritesModel: FavouritesModel(), listing: listing, image: productImage)
+                                ProductCard(favouritesModel: favouritesModel, listing: listing, image: productImage)
                             })
                         }
                     }
@@ -61,7 +62,7 @@ struct MyListingsView: View {
 
 struct MyListingsView_Previews: PreviewProvider {
     static var previews: some View {
-        MyListingsView(tabSelection: .constant(5))
+        MyListingsView(tabSelection: .constant(5), favouritesModel: FavouritesModel())
             .environmentObject(CurrentUser())
     }
 }

--- a/SH4RE/SH4RE/Account/ProfileView.swift
+++ b/SH4RE/SH4RE/Account/ProfileView.swift
@@ -13,6 +13,7 @@ struct ProfileView: View {
     @Binding var uid:String
     @Binding var profilePicture:UIImage
     @Binding var tabSelection: Int
+    @ObservedObject var favouritesModel: FavouritesModel
     @EnvironmentObject var currentUser: CurrentUser
     @State private var name:String = "" // if not name
     @State private var numberOfStars:Float = 4.0
@@ -49,9 +50,9 @@ struct ProfileView: View {
                             // If theres no image for a listing, just use the placeholder
                             let productImage = listingsView.image_dict[listing.id] ?? UIImage(named: "placeholder")!
                             NavigationLink(destination: {
-                                ViewListingView(tabSelection: $tabSelection, listing: listing, chatLogViewModel: chatLogViewModelDict[listing.id] ?? ChatLogViewModel(chatUser: ChatUser(id: listing.uid,uid: listing.uid, name: listing.ownerName))).environmentObject(currentUser)
+                                ViewListingView(tabSelection: $tabSelection, favouritesModel: favouritesModel, listing: listing, chatLogViewModel: chatLogViewModelDict[listing.id] ?? ChatLogViewModel(chatUser: ChatUser(id: listing.uid,uid: listing.uid, name: listing.ownerName))).environmentObject(currentUser)
                             }, label: {
-                                ProductCard(favouritesModel: FavouritesModel(), listing: listing, image: productImage)
+                                ProductCard(favouritesModel: favouritesModel, listing: listing, image: productImage)
                             })
                         }
                     }

--- a/SH4RE/SH4RE/ContentView.swift
+++ b/SH4RE/SH4RE/ContentView.swift
@@ -55,7 +55,7 @@ struct ContentView: View {
                             Label("Post", systemImage: "plus.square.fill")
                         }
                         .tag(3)
-                    MessagesInboxView(tabSelection: $tabSelection)
+                    MessagesInboxView(tabSelection: $tabSelection, favouritesModel: favouritesModel)
                         .environmentObject(currentUser)
                         .tabItem {
                             Label("Messages", systemImage: "message.fill")

--- a/SH4RE/SH4RE/Home/HomeView.swift
+++ b/SH4RE/SH4RE/Home/HomeView.swift
@@ -101,13 +101,13 @@ struct HomeView: View {
                                     let listing1 = recentListings.count >= 1 ? recentListings[0] : empty_listing
                                     let listing2 = recentListings.count >= 2 ? recentListings[1] : empty_listing
                                     NavigationLink(destination: {
-                                        ViewListingView(tabSelection: $tabSelection, listing: listing1, chatLogViewModel: chatLogViewModel1 ?? ChatLogViewModel(chatUser: ChatUser(id: listing1.uid, uid: listing1.uid, name: listing1.ownerName))).environmentObject(currentUser)
+                                        ViewListingView(tabSelection: $tabSelection, favouritesModel: favouritesModel, listing: listing1, chatLogViewModel: chatLogViewModel1 ?? ChatLogViewModel(chatUser: ChatUser(id: listing1.uid, uid: listing1.uid, name: listing1.ownerName))).environmentObject(currentUser)
                                     }, label: {
                                         ProductCard(favouritesModel: favouritesModel, listing: listing1, image: recentListing1Image)
                                     })
                                     Spacer()
                                     NavigationLink(destination: {
-                                        ViewListingView(tabSelection: $tabSelection, listing: listing2, chatLogViewModel: chatLogViewModel2 ?? ChatLogViewModel(chatUser: ChatUser(id: listing2.uid, uid: listing2.uid, name: listing2.ownerName))).environmentObject(currentUser)
+                                        ViewListingView(tabSelection: $tabSelection, favouritesModel: favouritesModel, listing: listing2, chatLogViewModel: chatLogViewModel2 ?? ChatLogViewModel(chatUser: ChatUser(id: listing2.uid, uid: listing2.uid, name: listing2.ownerName))).environmentObject(currentUser)
                                     }, label: {
                                         ProductCard(favouritesModel: favouritesModel, listing: listing2, image: recentListing2Image)
                                     })

--- a/SH4RE/SH4RE/Messages/MessagesChat.swift
+++ b/SH4RE/SH4RE/Messages/MessagesChat.swift
@@ -13,6 +13,7 @@ import FirebaseStorage
 struct MessagesChat: View {
     @Environment(\.presentationMode) var presentationMode
     @ObservedObject var vm: ChatLogViewModel
+    @ObservedObject var favouritesModel: FavouritesModel
     @Binding var tabSelection: Int
     @EnvironmentObject var currentUser: CurrentUser
     static let emptyScrollToString = "Empty"
@@ -69,7 +70,7 @@ struct MessagesChat: View {
                     .padding(.bottom)
             }
             ToolbarItem(placement: .navigationBarTrailing) {
-                NavigationLink(destination: ProfileView(uid: $uid, profilePicture: $profilePicture, tabSelection: $tabSelection, currentUser: _currentUser))
+                NavigationLink(destination: ProfileView(uid: $uid, profilePicture: $profilePicture, tabSelection: $tabSelection, favouritesModel: favouritesModel, currentUser: _currentUser))
                 {
                     Image(systemName: "info.circle.fill")
                 }

--- a/SH4RE/SH4RE/Messages/MessagesInboxView.swift
+++ b/SH4RE/SH4RE/Messages/MessagesInboxView.swift
@@ -15,6 +15,7 @@ struct MessagesInboxView: View {
     @State  var searchQuery: String = ""
     @EnvironmentObject var currentUser: CurrentUser
     @ObservedObject var vm = MainMessagesViewModel()
+    @ObservedObject var favouritesModel: FavouritesModel
     @State var shouldNavigateToChatLogView = false
     var chatLogViewModel = ChatLogViewModel(chatUser: nil)
     @State var profilePicDict : [String:UIImage] = [:]
@@ -42,7 +43,7 @@ struct MessagesInboxView: View {
                             messagesView
                         }
                         NavigationLink("", isActive: $shouldNavigateToChatLogView) {
-                            MessagesChat(vm: chatLogViewModel, tabSelection: $tabSelection, currentUser: _currentUser)
+                            MessagesChat(vm: chatLogViewModel, favouritesModel: favouritesModel, tabSelection: $tabSelection, currentUser: _currentUser)
                         }
                     }
                 }.onAppear(){

--- a/SH4RE/SH4RE/Messages/MessagesInboxView.swift
+++ b/SH4RE/SH4RE/Messages/MessagesInboxView.swift
@@ -32,7 +32,7 @@ struct MessagesInboxView: View {
                 UnverifiedView(tabSelection: $tabSelection).environmentObject(currentUser)
             }
             else {
-                NavigationView {
+                NavigationStack {
                     VStack {
                         customNavBar
                         if (vm.recentMessages.count == 0) {

--- a/SH4RE/SH4RE/Search/Components/ProductCard.swift
+++ b/SH4RE/SH4RE/Search/Components/ProductCard.swift
@@ -112,6 +112,7 @@ struct ProductCard: View {
         .background(.white)
         .cornerRadius(20)
         .onReceive(favouritesModel.favourites.publisher, perform:{ _ in
+            // In case the card appears before favs are recieved from server
             favourited = favouritesModel.isFavourited(listingID: listing.id)
         })
         .onAppear(perform:{

--- a/SH4RE/SH4RE/Search/Components/ProductCard.swift
+++ b/SH4RE/SH4RE/Search/Components/ProductCard.swift
@@ -114,6 +114,9 @@ struct ProductCard: View {
         .onReceive(favouritesModel.favourites.publisher, perform:{ _ in
             favourited = favouritesModel.isFavourited(listingID: listing.id)
         })
+        .onAppear(perform:{
+            favourited = favouritesModel.isFavourited(listingID: listing.id)
+        })
     }
 }
 

--- a/SH4RE/SH4RE/Search/MapView.swift
+++ b/SH4RE/SH4RE/Search/MapView.swift
@@ -25,6 +25,7 @@ struct MapView: View {
     @Binding var tabSelection: Int
     @Binding var chatLogViewModelDict:[String:ChatLogViewModel]
     @EnvironmentObject var currentUser: CurrentUser
+    @ObservedObject var favouritesModel: FavouritesModel
     @Binding var region:MKCoordinateRegion
     @ObservedObject var listingsView:ListingViewModel
     @State var listingPins:[MapLocation] = []
@@ -79,7 +80,7 @@ struct MapView: View {
         .safeAreaInset(edge: .bottom) {
             if (selectedListing != nil) {
                 NavigationLink(destination: {
-                    ViewListingView(tabSelection: $tabSelection, listing: selectedListing!.listing, chatLogViewModel: chatLogViewModelDict[selectedListing!.name] ?? ChatLogViewModel(chatUser: ChatUser(id: selectedListing?.listing.id,uid: (selectedListing?.listing.uid)!, name: (selectedListing?.listing.ownerName)!)) ).environmentObject(currentUser)
+                    ViewListingView(tabSelection: $tabSelection, favouritesModel: favouritesModel, listing: selectedListing!.listing, chatLogViewModel: chatLogViewModelDict[selectedListing!.name] ?? ChatLogViewModel(chatUser: ChatUser(id: selectedListing?.listing.id,uid: (selectedListing?.listing.uid)!, name: (selectedListing?.listing.ownerName)!))).environmentObject(currentUser)
                 }, label: {
                     LandscapeProductCard(listing: selectedListing!.listing, image: selectedListing!.productImage)
                 })

--- a/SH4RE/SH4RE/Search/SearchView.swift
+++ b/SH4RE/SH4RE/Search/SearchView.swift
@@ -98,7 +98,7 @@ struct SearchView: View {
                             Text("Filtered")
                                 .foregroundColor(.primaryDark)
                         }
-                        NavigationLink(destination: MapView(tabSelection: $tabSelection, chatLogViewModelDict: $chatLogViewModelDict, region: $locationManager.region, listingsView: listingsView).environmentObject(currentUser), label: {
+                        NavigationLink(destination: MapView(tabSelection: $tabSelection, chatLogViewModelDict: $chatLogViewModelDict, favouritesModel: favouritesModel, region: $locationManager.region, listingsView: listingsView).environmentObject(currentUser), label: {
                             HStack { 
                                 Text("View Map")
                                 Image(systemName: "map.fill")
@@ -115,7 +115,7 @@ struct SearchView: View {
                                 // If theres no image for a listing, just use the placeholder
                                 let productImage = listingsView.image_dict[listing.id] ?? UIImage(named: "placeholder")!
                                 NavigationLink(destination: {
-                                    ViewListingView(tabSelection: $tabSelection, listing: listing, chatLogViewModel: chatLogViewModelDict[listing.id] ?? ChatLogViewModel(chatUser: ChatUser(id: listing.uid,uid: listing.uid, name: listing.ownerName)) ).environmentObject(currentUser)
+                                    ViewListingView(tabSelection: $tabSelection, favouritesModel: favouritesModel, listing: listing, chatLogViewModel: chatLogViewModelDict[listing.id] ?? ChatLogViewModel(chatUser: ChatUser(id: listing.uid,uid: listing.uid, name: listing.ownerName))).environmentObject(currentUser)
                                 }, label: {
                                     ProductCard(favouritesModel: favouritesModel, listing: listing, image: productImage)
                                 })

--- a/SH4RE/SH4RE/ViewListing/ViewListingView.swift
+++ b/SH4RE/SH4RE/ViewListing/ViewListingView.swift
@@ -19,6 +19,7 @@ struct ViewListingView: View {
     @Environment(\.presentationMode) var presentationMode
     @Binding var tabSelection: Int
     @EnvironmentObject var currentUser: CurrentUser
+    @ObservedObject var favouritesModel: FavouritesModel
     
     //parameters passed in from search nav link
     @State var listing: Listing
@@ -308,7 +309,7 @@ struct ViewListingView: View {
                 }
                 Spacer()
                 
-                NavigationLink(destination: MessagesChat(vm:self.chatLogViewModel, tabSelection: $tabSelection)) {
+                NavigationLink(destination: MessagesChat(vm:self.chatLogViewModel, favouritesModel: favouritesModel, tabSelection: $tabSelection)) {
                     HStack {
                         Text("Send")
                             .font(.body)
@@ -420,6 +421,6 @@ struct ViewListingView_Previews: PreviewProvider {
     static var previewChatLogModel = ChatLogViewModel(chatUser: ChatUser(id: "Y4YBHDZDMEVo9yMVzGgBoVw2ZpH2", uid: "Y4YBHDZDMEVo9yMVzGgBoVw2ZpH2", name: "Random"))
     
     static var previews: some View {
-        ViewListingView(tabSelection: .constant(2), listing: previewListing, chatLogViewModel: previewChatLogModel)
+        ViewListingView(tabSelection: .constant(2), favouritesModel: FavouritesModel(), listing: previewListing, chatLogViewModel: previewChatLogModel)
     }
 }


### PR DESCRIPTION
Using the same favouritesModel around the app not only prevents many useless calls to the server for repeat data, but also ensures entire app stays in sync.
ALSO refactor MessagesInboxView, if  the NavigationsLinks were to collapse, isActive would sometimes cause them to force stay open even if ChatLogViewModel had been emptied, causing the app to crash. Refactored approach does not use `isActive`